### PR TITLE
used OS module to remove hard coded paths to files Beatrix-droid

### DIFF
--- a/certificate.py
+++ b/certificate.py
@@ -2,13 +2,12 @@ import cv2
 import os
 import base64
 import streamlit as st
-import numpy
-import sys
-from PIL import Image, ImageDraw
+from pathlib import Path
 font = cv2.FONT_HERSHEY_SIMPLEX
 fontScale = 3
 activities = ["Get certificate","About"]
-st.sidebar.image("images\\logo.png")
+cwd = os.getcwd()
+st.sidebar.image(os.path.join(cwd, "images","logo.png"))
 choice=st.sidebar.selectbox("Select Activty",activities)
 
 
@@ -19,7 +18,7 @@ def get_binary_file_downloader_html(bin_file, file_label='File'):
     href = f'<a href="data:application/octet-stream;base64,{bin_str}" download="{os.path.basename(bin_file)}">Download {file_label}</a>'
     return href
 def annotate(name):
-    certi = cv2.imread("images\\img.png")
+    certi = cv2.imread(os.path.join(cwd,"images","img.png"))
     original = cv2.putText(certi, name, (710, 790),font,   fontScale, (0, 0, 0), thickness=5)
     cv2.imwrite("Certificate.jpg",original)
 
@@ -30,7 +29,7 @@ def annotate(name):
 
 if choice =="Get certificate":
     st.title("Get Your Certificate")
-    img=cv2.imread('C:\\Users\\Admin\Desktop\\github\\certificates_streamlit\\pics\\apricus.png')
+    img=cv2.imread(os.path.join(cwd, "images","apricus.png"))
     na=st.text_input('Enter your name')
     annotate(na)
     #st.markdown(get_binary_file_downloader_html(original, 'Picture'), unsafe_allow_html=True)
@@ -40,4 +39,3 @@ if choice =="About":
     st.subheader("Cerficate App")
     st.markdown("</> with ❤ by Anirudh Soni" )
     st.markdown("connect with me 😃 (https://www.linkedin.com/in/heyanirudh)")
-


### PR DESCRIPTION
Removed unnecessary imports and used the OS module to remove all instances of hard coded paths to files, as some paths were hard coded for windows computers and wouldn't have worked on Unix or Unix like systems.
With this layer of abstraction, the app now runs on linux, and should be able to run on windows as well, as no values are hardcoded.
Test the app and let me know if it works on windows too 